### PR TITLE
Upgrade GNOME runtime from 48 (EOL) to 50

### DIFF
--- a/io.github.sigmasd.stimulator.yml
+++ b/io.github.sigmasd.stimulator.yml
@@ -1,7 +1,7 @@
 app-id: io.github.sigmasd.stimulator
 
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 
 command: stimulator

--- a/io.github.sigmasd.stimulator.yml
+++ b/io.github.sigmasd.stimulator.yml
@@ -65,6 +65,8 @@ modules:
       - type: script
         dest-filename: stimulator
         commands:
-          - DENO_PYTHON_PATH=/usr/lib/$(uname -m)-linux-gnu/libpython3.12.so.1.0 /app/bin/deno run --cached-only --allow-all --unstable-raw-imports /app/bin/runtime/src/main.ts
+          - |
+            PYTHON_SO=$(find /usr/lib/$(uname -m)-linux-gnu -name 'libpython3*.so.1*' | head -1)
+            DENO_PYTHON_PATH=$PYTHON_SO /app/bin/deno run --cached-only --allow-all --unstable-raw-imports /app/bin/runtime/src/main.ts
 
       - deno-sources.json


### PR DESCRIPTION
### Description

Proposing we upgrade the GNOME runtime in use from the EOL version 48 to the latest version 50. The latter runtime utilizes the Freedesktop SDK version 25.08. Additionally this PR does this following.
- Bumps `shared-modules` from [6ba63f3](https://github.com/flathub/shared-modules/commit/6ba63f383ad54e7ebe2b0cda64c15602cf9a9153) (over 2 years old) to [b8236c7](https://github.com/flathub/shared-modules/commit/b8236c7961e3dd447b1b9605375a54a12f9f24b6) (2 weeks old, latest) to address build issues with the newer runtime.
- Updates Python usage to dynamically look up a `libpython3` instead of locking to `libpython3.12`. Without this change, the flatpak fails to find a usable Python version and fails to run on runtime 50.

Supersedes https://github.com/flathub/io.github.sigmasd.stimulator/pull/36
Resolves https://github.com/sigmaSd/Stimulator/issues/128

### References

- https://release.gnome.org//50/
- https://release.gnome.org/50/developers/
- https://discourse.flathub.org/t/freedesktop-sdk-25-08-0-released/10399
- https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-25.08.0

### Notes

We could considering bumping more such as the Deno version but I've chosen to not do so in this PR.

### Testing

Tested via the following:

```
flatpak install --user https://dl.flathub.org/build-repo/277692/io.github.sigmasd.stimulator.flatpakref
```

<details>
<summary>Screenshots</summary>

<img width="2880" height="660" alt="Screenshot From 2026-04-23 16-18-08" src="https://github.com/user-attachments/assets/2e12783c-1961-468a-a99b-430976869545" />
<img width="1000" height="728" alt="Screenshot From 2026-04-23 16-18-22" src="https://github.com/user-attachments/assets/e23396e6-3bd4-496d-a996-74ced9038117" />
<img width="1000" height="728" alt="Screenshot From 2026-04-23 16-18-31" src="https://github.com/user-attachments/assets/6c044989-c09c-47b4-bd07-f9492bb6b716" />
<img width="1000" height="728" alt="Screenshot From 2026-04-23 16-18-38" src="https://github.com/user-attachments/assets/d680e88b-e185-48bd-8436-f834226a4ba0" />
<img width="1000" height="728" alt="Screenshot From 2026-04-23 16-18-43" src="https://github.com/user-attachments/assets/bd406758-49bd-4cc0-a003-fda0e76fc170" />
<img width="1200" height="740" alt="Screenshot From 2026-04-23 16-18-53" src="https://github.com/user-attachments/assets/ff54f20d-d8c5-4769-af38-82ce60d1d7fe" />
<img width="688" height="426" alt="Screenshot From 2026-04-23 16-19-01" src="https://github.com/user-attachments/assets/efdfc96a-1d06-4546-be43-dad4aae3c14a" />

</details>